### PR TITLE
feat: add highlights when type or scope is called with an array argument

### DIFF
--- a/contrib/queries/ecma/injections.scm
+++ b/contrib/queries/ecma/injections.scm
@@ -6,6 +6,11 @@
       (string_fragment) @injection.content))
 
     (arguments
+      (array
+        (string
+          (string_fragment) @injection.content)))
+
+    (arguments
       (object
         (pair
           key: ([(property_identifier) (string)]


### PR DESCRIPTION
Fixes #1

The line from arktype repo after this change:

<img width="624" height="210" alt="image" src="https://github.com/user-attachments/assets/45031f51-de10-4ac2-b72d-dc3bc3be8855" />

My small fix for "number":

<img width="637" height="305" alt="image" src="https://github.com/user-attachments/assets/c89d5d0b-5c8c-4c97-bc5d-d752b7866c72" />
